### PR TITLE
Adding `BITOPS_FAST_FAIL=true` to start command

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -64,6 +64,7 @@ runs:
         EC2_INSTANCE_PROFILE: ${{ inputs.ec2_instance_profile }}
         STACK_DESTROY: ${{ inputs.stack_destroy }}
         AWS_RESOURCE_IDENTIFIER: ${{ inputs.aws_resource_identifier }}
+        BITOPS_FAST_FAIL: true
       run: |
         echo "running operations/_scripts/deploy/deploy.sh"
         $GITHUB_ACTION_PATH/operations/_scripts/deploy/deploy.sh


### PR DESCRIPTION
I believe that the `BITOPS_FAST_FAIL` flag should be used for actions. 

My reasoning is; For accurate feedback to the Github Action console, BitOps needs to throw an error which does not happen with default behaviour (BitOps core is set to pass over failed steps)