### PR TITLE
[WIP] ELB Ports override

### DIFF
--- a/operations/deployment/terraform/elb.tf
+++ b/operations/deployment/terraform/elb.tf
@@ -52,7 +52,7 @@ resource "aws_elb" "vm_ssl" {
   listener {
     instance_port      = var.app_port
     instance_protocol  = "tcp"
-    lb_port            = var.app_port
+    lb_port            = var.lb_port != "" ? var.lb_port : 443
     lb_protocol        = "ssl"
     ssl_certificate_id = data.aws_acm_certificate.issued[0].arn
   }
@@ -61,7 +61,7 @@ resource "aws_elb" "vm_ssl" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:${var.app_port}/"
+    target              = var.lb_healthcheck != "" ? var.lb_healthcheck : "HTTP:${var.app_port}/"
     interval            = 30
   }
 
@@ -90,7 +90,7 @@ resource "aws_elb" "vm" {
   listener {
     instance_port      = var.app_port
     instance_protocol  = "tcp"
-    lb_port            = var.app_port
+    lb_port            = var.lb_port != "" ? var.lb_port : 80
     lb_protocol        = "tcp"
   }
 
@@ -98,7 +98,7 @@ resource "aws_elb" "vm" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "HTTP:${var.app_port}/"
+    target              = var.lb_healthcheck != "" ? var.lb_healthcheck : "HTTP:${var.app_port}/"
     interval            = 30
   }
 

--- a/operations/deployment/terraform/variables.tf
+++ b/operations/deployment/terraform/variables.tf
@@ -3,6 +3,16 @@ variable "app_port" {
   default = "3000"
   description = "app port"
 }
+variable "lb_port" {
+  type = string
+  default = ""
+  description = "Load balancer listening port. Defaults to 80 if NO FQDN provided, 443 if FQDN provided"
+}
+variable "lb_healthcheck" {
+  type = string
+  default = ""
+  description = "Load balancer health check string. Defaults to HTTP:app_port"
+}
 variable "app_repo_name" {
   type = string
   description = "GitHub Repo Name"


### PR DESCRIPTION
- Ports override for ELB. - If none defined ELB will use 443 if cert available, 80 if none.
- Healthcheck override for ELB. As a default, it will be HTTP:app_port/. If a string is provided, it should be complete. 