### PR TITLE
Improvements to shorten-identifier tool

### DIFF
--- a/operations/_scripts/generate/shorten_identifier.sh
+++ b/operations/_scripts/generate/shorten_identifier.sh
@@ -75,6 +75,14 @@ if [[ $IDENTIFIER =~ $re ]]; then
       IDENTIFIER=$(echo ${IDENTIFIER} | sed -e "s/${BASH_REMATCH[1]}//")
     done
   done
+  # If final length exceeds limit - get the firts part, last part, and create a hash in the middle
+  if [ ${#final_id} -gt $MAX_IDENTIFIER_LENGTH ]; then
+    max_length=$(( $MAX_IDENTIFIER_LENGTH - 8 ))
+    part1=$(echo $final_id | cut -d "-" -f 1)
+    part2=$(echo $final_id | cut -c 5- | rev | cut -c 5- | rev | md5sum | cut -c 1-$max_length)
+    part3=$(echo $final_id | rev | cut -d "-" -f 1 | rev)
+    final_id="$part1-$part2-$part3"
+  fi
   echo "$final_id"
 else
   echo "$IDENTIFIER"


### PR DESCRIPTION
The bash script will shorten strings between dashes up to 3 characters. If there are multiple dashes, might exceed limit. 

This improvement will replace the middle part of that replacement for a hash based on the string provided. 

`bitovi-devops-training-ec2-gha-example-testing-gha-d2ec2`
Would be transformed into
`b4i-d4s-t6g-ec2-gha-e5e-t5g-gha-d32`
Which still exceeds the 30 length limit.

With this fix it would be transformed into 
`b4i-344badfed9b5e4c6c87215-d32`