### PR TITLE
Bucket identifier length fix - Improve documentation about identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ The following inputs can be used as `step.with` keys
 | `aws_resource_identifier` | String | Set to override the AWS resource identifier for the deployment.  Defaults to `${org}-{repo}-{branch}`.  Use with destroy to destroy specific resources. |
 | `app_directory` | String | Relative path for the directory of the app (i.e. where `Dockerfile` and `docker-compose.yaml` files are located). This is the directory that is copied to the EC2 instance.  Default is the root of the repo. |
 
+## Note about resource identifiers
+
+Most resources will contain the tag GITHUB_ORG-GITHUB_REPO-GITHUB_BRANCH, some of them, even the resource name after. 
+We limit this to a 60 characters string because some AWS resources have a length limit and short it if needed.
+
+We use the kubernetes style for this. For example, kubernetes -> k(# of characters)s -> k8s. And so you might see some compressions are made.
+
+For some specific resources, we have a 32 characters limit. If the identifier length exceeds this number after compression, we remove the middle part and replace it for a hash made up from the string itself. 
+
+### S3 buckets naming
+
+Buckets name can be made of up to 63 characters. If the length allows us to add -tf-state, we will do so. If not, a simple -tf will be added.
+
 ## Made with BitOps
 [BitOps](https://bitops.sh) allows you to define Infrastructure-as-Code for multiple tools in a central place.  This action uses a BitOps [Operations Repository](https://bitops.sh/operations-repo-structure/) to set up the necessary Terraform and Ansible to create infrastructure and deploy to it.
 

--- a/operations/_scripts/generate/generate_tf_state_bucket.sh
+++ b/operations/_scripts/generate/generate_tf_state_bucket.sh
@@ -5,7 +5,12 @@ set -e
 if [ -z "${TF_STATE_BUCKET}" ]; then
 
   GITHUB_IDENTIFIER="$($GITHUB_ACTION_PATH/operations/_scripts/generate/generate_identifier.sh)"
-  export TF_STATE_BUCKET="${GITHUB_IDENTIFIER}-tf-state"
+  
+  if [[ ${#GITHUB_IDENTIFIER} < 55 ]]; then
+    export TF_STATE_BUCKET="${GITHUB_IDENTIFIER}-tf-state"
+  else
+    export TF_STATE_BUCKET="${GITHUB_IDENTIFIER}-tf"
+  fi
 fi
 
 echo "$TF_STATE_BUCKET"


### PR DESCRIPTION
If length is longer than 54 character limit, it will just add `-tf`

If not, it will add `-tf-state`

This way, we are not generating a breaking change. 