### PR TITLE
Option to create release with generated IaC

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,41 +111,42 @@ jobs:
 
 The following inputs can be used as `step.with` keys
 
-| Name             | Type    | Description                        | default |
-|------------------|---------|------------------------------------|---------|
-| `checkout` | Boolean | Set to `false` if the code is already checked out (Optional) |true|
-| `create_release` | Boolean | Set to `true` to create a new release based on the branch name with gz compressed files of the generated IaC. (Optional) |false|
-| `aws_access_key_id` | String | AWS access key ID ||
-| `aws_secret_access_key` | String | AWS secret access key ||
-| `aws_session_token` | String | AWS session token ||
-| `aws_default_region` | String | AWS default region ||
-| `aws_ami_id` | String | AWS AMI ID. Accepts `ami-####` values | latest Ubuntu 22.04 server image (HVM)|
-| `domain_name` | String | Define the root domain name for the application. e.g. bitovi.com' ||
-| `sub_domain` | String | Define the sub-domain part of the URL. | `${org}-${repo}-{branch}` |
-| `root_domain` | Boolean | Deploy application to root domain. Will create root and www records. |false|
-| `cert_arn` | String | Define the certificate ARN to use for the application. **See note ** ||
-| `create_root_cert` | Boolean | Generates and manage the root cert for the application. **See note **. |false|
-| `create_sub_cert` | Boolean | Generates and manage the sub-domain certificate for the application. **See note **. |false|
-| `no_cert` | Boolean | Set this to true if no certificate is present for the domain. **See note **. |false|
-| `tf_state_bucket` | String | AWS S3 bucket to use for Terraform state. ||
-| `tf_state_bucket_destroy` | Boolean | Force purge and deletion of S3 bucket defined. Any file contained there will be destroyed.|false - `stack_destroy` must also be `true`|
-| `repo_env` | String | `.env` file containing environment variables to be used with the app. Name defaults to `repo_env`. Check **Environment variables** note ||
-| `dot_env` | String | `.env` file to be used with the app. This is the name of the [Github secret](https://docs.github.com/es/actions/security-guides/encrypted-secrets). Check **Environment variables** note ||
-| `ghv_env` | String | `.env` file to be used with the app. This is the name of the [Github variables](https://docs.github.com/en/actions/learn-github-actions/variables). Check **Environment variables** note ||
-| `aws_secret_env` | String | Secret name to pull environment variables from AWS Secret Manager. Check **Environment variables** note |
-| `app_port` | String | port to expose for the app ||
-| `lb_port` | String | Load balancer listening port. |80 if NO FQDN provided, 443 if FQDN provided|
-| `lb_healthcheck` | String | Load balancer health check string. |HTTP:app_port|
-| `ec2_instance_profile` | String | The AWS IAM instance profile to use for the EC2 instance. |`${GITHUB_ORG_NAME}-${GITHUB_REPO_NAME}-${GITHUB_BRANCH_NAME}`|
-| `ec2_instance_type` | String | The AWS IAM instance type to use. See [this list](https://aws.amazon.com/ec2/instance-types/) for reference |t2.small|
-| `stack_destroy` | String | Set to `true` to destroy the stack. Default is `""` - Will delete the elb_logs bucket after the destroy action runs. ||
-| `aws_resource_identifier` | String | Set to override the AWS resource identifier for the deployment. Use with destroy to destroy specific resources. |`${org}-{repo}-{branch}`|
-| `app_directory` | String | Relative path for the directory of the app (i.e. where `Dockerfile` and `docker-compose.yaml` files are located). This is the directory that is copied to the EC2 instance. |app repo root|
-| `additional_tags` | JSON | Add additional tags to the terraform [default tags](https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider), any tags put here will be added to all provisioned resources.||
+| Name             | Type    | Default | Description                        |
+|------------------|---------|---------|------------------------------------|
+| `checkout` | Boolean | true | Set to `false` if the code is already checked out (Optional) |
+| `create_release` | Boolean | false | Set to `true` to create a new release based on the branch name with gz compressed files of the generated IaC. (Optional) |
+| `aws_access_key_id` | String | | AWS access key ID |
+| `aws_secret_access_key` | String | | AWS secret access key |
+| `aws_session_token` | String | | AWS session token |
+| `aws_default_region` | String | us-east-1 | AWS default region |
+| `aws_ami_id` | String | latest Ubuntu 22.04 server image (HVM)| AWS AMI ID. Accepts `ami-####` values . |
+| `domain_name` | String | | Define the root domain name for the application. e.g. bitovi.com' |
+| `sub_domain` | String | `${org}-${repo}-{branch}` | Define the sub-domain part of the URL. |
+| `root_domain` | Boolean | false | Deploy application to root domain. Will create root and www records. |
+| `cert_arn` | String | | Define the certificate ARN to use for the application. **See note ** |
+| `create_root_cert` | Boolean | false | Generates and manage the root cert for the application. **See note **. |
+| `create_sub_cert` | Boolean | false |Generates and manage the sub-domain certificate for the application. **See note **.|
+| `no_cert` | Boolean | false | Set this to true if no certificate is present for the domain. **See note **. |
+| `tf_state_bucket` | String || AWS S3 bucket to use for Terraform state. |
+| `tf_state_bucket_destroy` | Boolean | false - `stack_destroy` must also be `true` |Force purge and deletion of S3 bucket defined. Any file contained there will be destroyed.|
+| `repo_env` | String | repo_env | `.env` file containing environment variables to be used with the app. Name defaults to `repo_env`. Check **Environment variables** note |
+| `dot_env` | String || `.env` file to be used with the app. This is the name of the [Github secret](https://docs.github.com/es/actions/security-guides/encrypted-secrets). Check **Environment variables** note |
+| `ghv_env` | String || `.env` file to be used with the app. This is the name of the [Github variables](https://docs.github.com/en/actions/learn-github-actions/variables). Check **Environment variables** note |
+| `aws_secret_env` | String | | Secret name to pull environment variables from AWS Secret Manager. Check **Environment variables** note |
+| `app_port` | String | 3000 |port to expose for the app |
+| `lb_port` | String | 80 if NO FQDN provided, 443 if FQDN provided| Load balancer listening port. |
+| `lb_healthcheck` | String | HTTP:app_port |Load balancer health check string. |
+| `ec2_instance_profile` | String | [Note about resource identifiers](#note-about-resource-identifiers) | The AWS IAM instance profile to use for the EC2 instance. |
+| `ec2_instance_type` | String | t2.small | The AWS IAM instance type to use. See [this list](https://aws.amazon.com/ec2/instance-types/) for reference |
+| `stack_destroy` | String | false | Set to `true` to destroy the stack. Default is `""` - Will delete the elb_logs bucket after the destroy action runs. |
+| `aws_resource_identifier` | String | `${org}-{repo}-{branch}` |Set to override the AWS resource identifier for the deployment. Use with destroy to destroy specific resources. |
+| `app_directory` | String | app repo root |Relative path for the directory of the app (i.e. where `Dockerfile` and `docker-compose.yaml` files are located). This is the directory that is copied to the EC2 instance. |
+| `additional_tags` | JSON || Add additional tags to the terraform [default tags](https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider), any tags put here will be added to all provisioned resources.|
 
 ## Note about resource identifiers
 
-Most resources will contain the tag GITHUB_ORG-GITHUB_REPO-GITHUB_BRANCH, some of them, even the resource name after. 
+Most resources will contain the tag 
+GITHUB_ORG-GITHUB_REPO-GITHUB_BRANCH, some of them, even the resource name after. 
 We limit this to a 60 characters string because some AWS resources have a length limit and short it if needed.
 
 We use the kubernetes style for this. For example, kubernetes -> k(# of characters)s -> k8s. And so you might see some compressions are made.

--- a/README.md
+++ b/README.md
@@ -111,37 +111,37 @@ jobs:
 
 The following inputs can be used as `step.with` keys
 
-| Name             | Type    | Description                        |
-|------------------|---------|------------------------------------|
-| `checkout` | Boolean | Set to `false` if the code is already checked out (Default is `true`) (Optional) |
-| `create_release` | Boolean | Set to `true` to create a new release based on the branch name with gz compressed files of the generated IaC. (Default is `false`) (Optional) |
-| `aws_access_key_id` | String | AWS access key ID |
-| `aws_secret_access_key` | String | AWS secret access key |
-| `aws_session_token` | String | AWS session token |
-| `aws_default_region` | String | AWS default region |
-| `aws_ami_id` | String | AWS AMI ID. Will default to latest Ubuntu 22.04 server image (HVM). Accepts `ami-####` values |
-| `domain_name` | String | Define the root domain name for the application. e.g. bitovi.com' |
-| `sub_domain` | String | Define the sub-domain part of the URL. Defaults to `${org}-${repo}-{branch}` |
-| `root_domain` | Boolean | Deploy application to root domain. Will create root and www records. Defaults to `false` |
-| `cert_arn` | String | Define the certificate ARN to use for the application. **See note ** |
-| `create_root_cert` | Boolean | Generates and manage the root cert for the application. **See note **. Defaults to `false` |
-| `create_sub_cert` | Boolean | Generates and manage the sub-domain certificate for the application. **See note **. Defaults to `false` |
-| `no_cert` | Boolean | Set this to true if no certificate is present for the domain. **See note **. Defaults to `false` |
-| `tf_state_bucket` | String | AWS S3 bucket to use for Terraform state. |
-| `tf_state_bucket_destroy` | Boolean | Force purge and deletion of S3 bucket defined. Any file contained there will be destroyed. (Default is `false`). `stack_destroy` must also be `true`|
-| `repo_env` | String | `.env` file containing environment variables to be used with the app. Name defaults to `repo_env`. Check **Environment variables** note |
-| `dot_env` | String | `.env` file to be used with the app. This is the name of the [Github secret](https://docs.github.com/es/actions/security-guides/encrypted-secrets). Check **Environment variables** note |
-| `ghv_env` | String | `.env` file to be used with the app. This is the name of the [Github variables](https://docs.github.com/en/actions/learn-github-actions/variables). Check **Environment variables** note |
+| Name             | Type    | Description                        | default |
+|------------------|---------|------------------------------------|---------|
+| `checkout` | Boolean | Set to `false` if the code is already checked out (Optional) |true|
+| `create_release` | Boolean | Set to `true` to create a new release based on the branch name with gz compressed files of the generated IaC. (Optional) |false|
+| `aws_access_key_id` | String | AWS access key ID ||
+| `aws_secret_access_key` | String | AWS secret access key ||
+| `aws_session_token` | String | AWS session token ||
+| `aws_default_region` | String | AWS default region ||
+| `aws_ami_id` | String | AWS AMI ID. Accepts `ami-####` values | latest Ubuntu 22.04 server image (HVM)|
+| `domain_name` | String | Define the root domain name for the application. e.g. bitovi.com' ||
+| `sub_domain` | String | Define the sub-domain part of the URL. | `${org}-${repo}-{branch}` |
+| `root_domain` | Boolean | Deploy application to root domain. Will create root and www records. |false|
+| `cert_arn` | String | Define the certificate ARN to use for the application. **See note ** ||
+| `create_root_cert` | Boolean | Generates and manage the root cert for the application. **See note **. |false|
+| `create_sub_cert` | Boolean | Generates and manage the sub-domain certificate for the application. **See note **. |false|
+| `no_cert` | Boolean | Set this to true if no certificate is present for the domain. **See note **. |false|
+| `tf_state_bucket` | String | AWS S3 bucket to use for Terraform state. ||
+| `tf_state_bucket_destroy` | Boolean | Force purge and deletion of S3 bucket defined. Any file contained there will be destroyed.|false - `stack_destroy` must also be `true`|
+| `repo_env` | String | `.env` file containing environment variables to be used with the app. Name defaults to `repo_env`. Check **Environment variables** note ||
+| `dot_env` | String | `.env` file to be used with the app. This is the name of the [Github secret](https://docs.github.com/es/actions/security-guides/encrypted-secrets). Check **Environment variables** note ||
+| `ghv_env` | String | `.env` file to be used with the app. This is the name of the [Github variables](https://docs.github.com/en/actions/learn-github-actions/variables). Check **Environment variables** note ||
 | `aws_secret_env` | String | Secret name to pull environment variables from AWS Secret Manager. Check **Environment variables** note |
-| `app_port` | String | port to expose for the app |
-| `lb_port` | String | Load balancer listening port. Defaults to 80 if NO FQDN provided, 443 if FQDN provided |
-| `lb_healthcheck` | String | Load balancer health check string. Defaults to HTTP:app_port |
-| `ec2_instance_profile` | String | The AWS IAM instance profile to use for the EC2 instance. Default is `${GITHUB_ORG_NAME}-${GITHUB_REPO_NAME}-${GITHUB_BRANCH_NAME}` |
-| `ec2_instance_type` | String | The AWS IAM instance type to use. Default is t2.small. See [this list](https://aws.amazon.com/ec2/instance-types/) for reference |
-| `stack_destroy` | String | Set to `true` to destroy the stack. Default is `""` - Will delete the elb_logs bucket after the destroy action runs. |
-| `aws_resource_identifier` | String | Set to override the AWS resource identifier for the deployment.  Defaults to `${org}-{repo}-{branch}`.  Use with destroy to destroy specific resources. |
-| `app_directory` | String | Relative path for the directory of the app (i.e. where `Dockerfile` and `docker-compose.yaml` files are located). This is the directory that is copied to the EC2 instance. Default is the root of the repo. |
-| `additional_tags` | JSON | Add additional tags to the terraform [default tags](https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider), any tags put here will be added to all provisioned resources.|
+| `app_port` | String | port to expose for the app ||
+| `lb_port` | String | Load balancer listening port. |80 if NO FQDN provided, 443 if FQDN provided|
+| `lb_healthcheck` | String | Load balancer health check string. |HTTP:app_port|
+| `ec2_instance_profile` | String | The AWS IAM instance profile to use for the EC2 instance. |`${GITHUB_ORG_NAME}-${GITHUB_REPO_NAME}-${GITHUB_BRANCH_NAME}`|
+| `ec2_instance_type` | String | The AWS IAM instance type to use. See [this list](https://aws.amazon.com/ec2/instance-types/) for reference |t2.small|
+| `stack_destroy` | String | Set to `true` to destroy the stack. Default is `""` - Will delete the elb_logs bucket after the destroy action runs. ||
+| `aws_resource_identifier` | String | Set to override the AWS resource identifier for the deployment. Use with destroy to destroy specific resources. |`${org}-{repo}-{branch}`|
+| `app_directory` | String | Relative path for the directory of the app (i.e. where `Dockerfile` and `docker-compose.yaml` files are located). This is the directory that is copied to the EC2 instance. |app repo root|
+| `additional_tags` | JSON | Add additional tags to the terraform [default tags](https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider), any tags put here will be added to all provisioned resources.||
 
 ## Note about resource identifiers
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ The following inputs can be used as `step.with` keys
 
 | Name             | Type    | Description                        |
 |------------------|---------|------------------------------------|
-| `checkout`          | Boolean | Set to `false` if the code is already checked out (Default is `true`) (Optional) |
+| `checkout` | Boolean | Set to `false` if the code is already checked out (Default is `true`) (Optional) |
+| `create_release` | Boolean | Set to `true` to create a new release based on the branch name with gz compressed files of the generated IaC. (Default is `false`) (Optional) |
 | `aws_access_key_id` | String | AWS access key ID |
 | `aws_secret_access_key` | String | AWS secret access key |
 | `aws_session_token` | String | AWS session token |

--- a/action.yaml
+++ b/action.yaml
@@ -11,6 +11,8 @@ inputs:
   create_release:
     description: 'Compress resulting terraform and ansible files and create a new release'
     default: false
+  github_token:
+    description: "A GITUB_TOKEN with the `content: write` permissions"
   aws_access_key_id:
     description: 'AWS access key ID'
     required: true
@@ -153,7 +155,7 @@ runs:
       with:
         GHR_PATH: ${{ github.action_path }}/operations/deployment/
         GHR_COMPRESS: gz
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
     
     # output results to GitHub
     - if: ${{ success() && steps.deploy.outputs.vm_url != '' }}

--- a/action.yaml
+++ b/action.yaml
@@ -146,13 +146,10 @@ runs:
         $GITHUB_ACTION_PATH/operations/_scripts/deploy/deploy.sh
         echo "running operations/_scripts/deploy/export_vars.sh"
         $GITHUB_ACTION_PATH/operations/_scripts/deploy/export_vars.sh
+        echo "exporting generated files"
+        cp -r $GITHUB_ACTION_PATH/operations/deployment/ ../deployment
 
     # Release
-    - if: ${{ inputs.create_release }}
-      name: testing
-      run: |
-        ls ${{ github.action_path }}
-        ls ${{ github.action_path }}/operations/deployment/
     - if: ${{ inputs.create_release }}
       name: Archive Release
       uses: thedoctor0/zip-release@0.7.0
@@ -160,7 +157,20 @@ runs:
         type: 'zip'
         filename: 'release.zip'
         exclusions: '*.git* /*node_modules/* .editorconfig'
-        path: ${{ github.action_path }}/operations/deployment/
+        path: ../deployment
+    - if: ${{ inputs.create_release }}
+      name: testing
+      run: |
+        ls ${{ github.action_path }}
+        echo "|----------------------------|"
+        ls ${{ github.action_path }}/operations/deployment/
+        echo "|----------------------------|"
+        ls .
+        echo "|----------------------------|"
+        ls ..
+        echo "|----------------------------|"
+        ls ../..
+      shell: bash
     - if: ${{ inputs.create_release }}
       name: Create a GitHub release
       uses: ncipollo/release-action@v1

--- a/action.yaml
+++ b/action.yaml
@@ -159,9 +159,9 @@ runs:
         artifactContentType: gz
         draft: true
         generateReleaseNotes: true
-        name: ${{ github.ref }}
+        name: ${{ github.ref_name }} branch
         replacesArtifacts: true
-        tag: ${{ github.ref  }} 
+        tag: ${{ github.ref_name  }}
     
     # output results to GitHub
     - if: ${{ success() && steps.deploy.outputs.vm_url != '' }}

--- a/action.yaml
+++ b/action.yaml
@@ -152,7 +152,7 @@ runs:
     - if: ${{ inputs.create_release }}
       name: Compress and Release
       uses: fnkr/github-action-ghr@v1.3
-      with:
+      env:
         GHR_PATH: ${{ github.action_path }}/operations/deployment/
         GHR_COMPRESS: gz
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}

--- a/action.yaml
+++ b/action.yaml
@@ -155,8 +155,8 @@ runs:
       name: Create a GitHub release
       uses: ncipollo/release-action@v1
       with:
-        tag: ${GITHUB_REF}
-        name: Release ${GITHUB_REF}
+        tag: $GITHUB_REF
+        name: Release $GITHUB_REF
     
     - if: ${{ inputs.create_release }}
       name: Compress and Release

--- a/action.yaml
+++ b/action.yaml
@@ -157,6 +157,7 @@ runs:
       with:
         tag: ${{ github.ref  }} 
         name: ${{ github.ref }}
+        skipIfReleaseExists: true
     
     - if: ${{ inputs.create_release }}
       name: Compress and Release
@@ -164,7 +165,7 @@ runs:
       env:
         GHR_PATH: ${{ github.action_path }}/operations/deployment/
         GHR_COMPRESS: gz
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
         GHR_REPLACE: true
     
     # output results to GitHub

--- a/action.yaml
+++ b/action.yaml
@@ -149,24 +149,19 @@ runs:
         echo "running operations/_scripts/deploy/export_vars.sh"
         $GITHUB_ACTION_PATH/operations/_scripts/deploy/export_vars.sh
 
-
     # Release
     - if: ${{ inputs.create_release }}
       name: Create a GitHub release
       uses: ncipollo/release-action@v1
       with:
-        tag: ${{ github.ref  }} 
+        allowUpdates: true
+        artifacts: ${{ github.action_path }}/operations/deployment/
+        artifactContentType: gz
+        draft: true
+        generateReleaseNotes: true
         name: ${{ github.ref }}
-        skipIfReleaseExists: true
-    
-    - if: ${{ inputs.create_release }}
-      name: Compress and Release
-      uses: fnkr/github-action-ghr@v1.3
-      env:
-        GHR_PATH: ${{ github.action_path }}/operations/deployment/
-        GHR_COMPRESS: gz
-        GITHUB_TOKEN: ${{ inputs.github_token }}
-        GHR_REPLACE: true
+        replacesArtifacts: true
+        tag: ${{ github.ref  }} 
     
     # output results to GitHub
     - if: ${{ success() && steps.deploy.outputs.vm_url != '' }}

--- a/action.yaml
+++ b/action.yaml
@@ -11,8 +11,6 @@ inputs:
   create_release:
     description: 'Compress resulting terraform and ansible files and create a new release'
     default: false
-  github_token:
-    description: "A GITUB_TOKEN with the `content: write` permissions"
   aws_access_key_id:
     description: 'AWS access key ID'
     required: true

--- a/action.yaml
+++ b/action.yaml
@@ -165,6 +165,7 @@ runs:
         GHR_PATH: ${{ github.action_path }}/operations/deployment/
         GHR_COMPRESS: gz
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        GHR_REPLACE: true
     
     # output results to GitHub
     - if: ${{ success() && steps.deploy.outputs.vm_url != '' }}

--- a/action.yaml
+++ b/action.yaml
@@ -149,6 +149,19 @@ runs:
 
     # Release
     - if: ${{ inputs.create_release }}
+      name: testing
+      run: |
+        ls ${{ github.action_path }}
+        ls ${{ github.action_path }}/operations/deployment/
+    - if: ${{ inputs.create_release }}
+      name: Archive Release
+      uses: thedoctor0/zip-release@0.7.0
+      with:
+        type: 'zip'
+        filename: 'release.zip'
+        exclusions: '*.git* /*node_modules/* .editorconfig'
+        path: ${{ github.action_path }}/operations/deployment/
+    - if: ${{ inputs.create_release }}
       name: Create a GitHub release
       uses: ncipollo/release-action@v1
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -155,8 +155,8 @@ runs:
       name: Create a GitHub release
       uses: ncipollo/release-action@v1
       with:
-        tag: ${GITHUB_REF##*/}
-        name: Release ${GITHUB_REF##*/}
+        tag: ${GITHUB_REF}
+        name: Release ${GITHUB_REF}
     
     - if: ${{ inputs.create_release }}
       name: Compress and Release

--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,9 @@ inputs:
     description: 'Specifies if this action should checkout the code'
     required: false
     default: 'true'
+  create_release:
+    description: 'Compress resulting terraform and ansible files and create a new release'
+    default: false
   aws_access_key_id:
     description: 'AWS access key ID'
     required: true
@@ -144,6 +147,14 @@ runs:
         echo "running operations/_scripts/deploy/export_vars.sh"
         $GITHUB_ACTION_PATH/operations/_scripts/deploy/export_vars.sh
 
+    - if: ${{ inputs.create_release }}
+      name: Compress and Release
+      uses: fnkr/github-action-ghr@v1.3
+      with:
+        GHR_PATH: ${{ github.action_path }}/operations/deployment/
+        GHR_COMPRESS: gz
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
     # output results to GitHub
     - if: ${{ success() && steps.deploy.outputs.vm_url != '' }}
       name: Print result created

--- a/action.yaml
+++ b/action.yaml
@@ -157,27 +157,14 @@ runs:
         type: 'zip'
         filename: 'release.zip'
         exclusions: '*.git* /*node_modules/* .editorconfig'
-        path: ../deployment
-    - if: ${{ inputs.create_release }}
-      name: testing
-      run: |
-        ls ${{ github.action_path }}
-        echo "|----------------------------|"
-        ls ${{ github.action_path }}/operations/deployment/
-        echo "|----------------------------|"
-        ls .
-        echo "|----------------------------|"
-        ls ..
-        echo "|----------------------------|"
-        ls ../..
-      shell: bash
+        path: ./deployment
+        directory: ../
     - if: ${{ inputs.create_release }}
       name: Create a GitHub release
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: true
-        artifacts: ${{ github.action_path }}/operations/deployment/
-        artifactContentType: gz
+        artifacts: ../release.zip
         draft: true
         generateReleaseNotes: true
         name: ${{ github.ref_name }} branch

--- a/action.yaml
+++ b/action.yaml
@@ -149,6 +149,15 @@ runs:
         echo "running operations/_scripts/deploy/export_vars.sh"
         $GITHUB_ACTION_PATH/operations/_scripts/deploy/export_vars.sh
 
+
+    # Release
+    - if: ${{ inputs.create_release }}
+      name: Create a GitHub release
+      uses: ncipollo/release-action@v1
+      with:
+        tag: ${GITHUB_REF##*/}
+        name: Release ${GITHUB_REF##*/}
+    
     - if: ${{ inputs.create_release }}
       name: Compress and Release
       uses: fnkr/github-action-ghr@v1.3

--- a/action.yaml
+++ b/action.yaml
@@ -155,8 +155,8 @@ runs:
       name: Create a GitHub release
       uses: ncipollo/release-action@v1
       with:
-        tag: $GITHUB_REF
-        name: Release $GITHUB_REF
+        tag: ${{ github.ref  }} 
+        name: ${{ github.ref }}
     
     - if: ${{ inputs.create_release }}
       name: Compress and Release

--- a/action.yaml
+++ b/action.yaml
@@ -156,7 +156,7 @@ runs:
       with:
         type: 'zip'
         filename: 'release.zip'
-        exclusions: '*.git* /*node_modules/* .editorconfig'
+        exclusions: '*.git* /*node_modules/* .editorconfig ghs.env inventory.yaml'
         path: ./deployment
         directory: ../
     - if: ${{ inputs.create_release }}


### PR DESCRIPTION
## README.md
This diff adds a new input option for `create_release` and a default value for `aws_ami_id` to the list of input options for jobs. It also adds default values for some existing input options, as well as clarifying descriptions for the existing options.

## action.yaml
This diff adds two new inputs to the action.yaml file, creates a new release by compressing the resulting terraform and ansible files and then creates a GitHub release with the generated release.zip artifact. The release will be a draft and will have the same name as the branch.