### PR TITLE
Adding Secret Manager entry for EC2 KeyPair

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The following inputs can be used as `step.with` keys
 | `stack_destroy` | String | Set to `true` to destroy the stack. Default is `""` - Will delete the elb_logs bucket after the destroy action runs. |
 | `aws_resource_identifier` | String | Set to override the AWS resource identifier for the deployment.  Defaults to `${org}-{repo}-{branch}`.  Use with destroy to destroy specific resources. |
 | `app_directory` | String | Relative path for the directory of the app (i.e. where `Dockerfile` and `docker-compose.yaml` files are located). This is the directory that is copied to the EC2 instance. Default is the root of the repo. |
+| `create_keypair_sm_entry` | Boolean | Generates and manage a secret manager entry that contains the public and private keys created for the ec2 instance. |
 | `additional_tags` | JSON | Add additional tags to the terraform [default tags](https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider), any tags put here will be added to all provisioned resources.|
 
 ## Note about resource identifiers

--- a/action.yaml
+++ b/action.yaml
@@ -88,6 +88,10 @@ inputs:
     required: false
   app_directory:
     description: 'Relative path for the directory of the app (i.e. where `Dockerfile` and `docker-compose.yaml` files are located). This is the directory that is copied to the EC2 instance.  Default is the root of the repo.'
+  create_keypair_sm_entry:
+    required: false
+    description: "Generates and manage a secret manager entry that contains the public and private keys created for the ec2 instance."
+    default: false
   additional_tags:
     description: 'A list of additional tags that will be included on created resources. Example: `{"key1": "value1", "key2": "value2"}`'
     required: false
@@ -137,6 +141,7 @@ runs:
         NO_CERT: ${{ inputs.no_cert }}
         BITOPS_FAST_FAIL: true
         APP_DIRECTORY: ${{ inputs.app_directory }}
+        CREATE_KEYPAIR_SM_ENTRY: ${{ inputs.create_keypair_sm_entry }}
         ADDITIONAL_TAGS: ${{ inputs.additional_tags }}
       run: |
         echo "running operations/_scripts/deploy/deploy.sh"

--- a/operations/_scripts/generate/generate_tf_vars.sh
+++ b/operations/_scripts/generate/generate_tf_vars.sh
@@ -88,6 +88,8 @@ create_sub_cert = \"${CREATE_SUB_CERT}\"
 
 no_cert = \"${NO_CERT}\"
 
+create_keypair_sm_entry = \"${CREATE_KEYPAIR_SM_ENTRY}\"
+
 additional_tags = ${ADDITIONAL_TAGS}
 #
 " >> "${GITHUB_ACTION_PATH}/operations/deployment/terraform/terraform.tfvars"

--- a/operations/deployment/terraform/main.tf
+++ b/operations/deployment/terraform/main.tf
@@ -12,7 +12,7 @@ resource "aws_key_pair" "aws_key" {
 // Creates a secret manager secret for the public key
 resource "aws_secretsmanager_secret" "keys_sm_secret" {
   count              = var.create_keypair_sm_entry ? 1 : 0
-  name   = "${var.aws_resource_identifier_supershort}-ec2kp-pub-${random_string.random.result}"
+  name   = "${var.aws_resource_identifier_supershort}-sm-${random_string.random.result}"
 }
  
 resource "aws_secretsmanager_secret_version" "keys_sm_secret_version" {

--- a/operations/deployment/terraform/main.tf
+++ b/operations/deployment/terraform/main.tf
@@ -3,9 +3,38 @@ resource "tls_private_key" "key" {
   rsa_bits  = 4096
 }
 
+// Creates an ec2 key pair using the tls_private_key.key public key
 resource "aws_key_pair" "aws_key" {
-  key_name   = "${var.aws_resource_identifier}"
+  key_name   = "${var.aws_resource_identifier_supershort}-ec2kp-${random_string.random.result}"
   public_key = tls_private_key.key.public_key_openssh
+}
+
+// Creates a secret manager secret for the public key
+resource "aws_secretsmanager_secret" "keys_sm_secret" {
+  count              = var.create_keypair_sm_entry ? 1 : 0
+  name   = "${var.aws_resource_identifier_supershort}-ec2kp-pub-${random_string.random.result}"
+}
+ 
+resource "aws_secretsmanager_secret_version" "keys_sm_secret_version" {
+  count     = var.create_keypair_sm_entry ? 1 : 0
+  secret_id = aws_secretsmanager_secret.keys_sm_secret[0].id
+  secret_string = <<EOF
+   {
+    "key": "public_key",
+    "value": "${sensitive(tls_private_key.key.public_key_openssh)}"
+   },
+   {
+    "key": "private_key",
+    "value": "${sensitive(tls_private_key.key.private_key_openssh)}"
+   }
+EOF
+}
+
+resource "random_string" "random" {
+  length    = 5
+  lower     = true
+  special   = false
+  numeric   = false
 }
 
 resource "aws_iam_instance_profile" "ec2_profile" {
@@ -45,4 +74,3 @@ output "instance_public_dns" {
   description = "Public DNS address of the EC2 instance"
   value       = var.ec2_instance_public_ip ? aws_instance.server.public_dns : "EC2 Instance doesn't have public DNS"
 }
-

--- a/operations/deployment/terraform/variables.tf
+++ b/operations/deployment/terraform/variables.tf
@@ -129,6 +129,12 @@ variable "no_cert" {
   default = ""
 }
 
+variable "create_keypair_sm_entry" {
+  type = bool
+  description = "y/n create sm entry for ec2 keypair"
+  default = false
+}
+
 variable "additional_tags" {
   type = map(string)
   description = "A list of strings that will be added to created resources"


### PR DESCRIPTION
## README.md
This diff adds a new option to the list of inputs that can be used as "step.with" keys; this new option is called "create_keypair_sm_entry" and is a Boolean value which generates and manages a secret manager entry that contains the public and private keys created for the ec2 instance.

## action.yaml
This diff adds an input option called 'create_keypair_sm_entry' with a description and default value, as well as an additional environment variable to the run section called 'CREATE_KEYPAIR_SM_ENTRY'.

## operations/_scripts/generate/generate_tf_vars.sh
This diff adds a new variable, "create_keypair_sm_entry", to the operations/_scripts/generate/generate_tf_vars.sh file, and adds a new resource block to the operations/deployment/terraform/main.tf file which creates an EC2 key pair, as well as a secret manager secret for the public key. It also adds a random_string resource to the main.tf file.

## operations/deployment/terraform/main.tf
This diff changes the way an ec2 key pair is created and adds a secret manager secret to store the public and private keys. A random string is also added to the key name for uniqueness. Lastly, an output is provided for the public DNS address of the EC2 instance.

## operations/deployment/terraform/variables.tf
This diff shows the addition of a new variable called "create_keypair_sm_entry" of type boolean, with a description and a default value of false, to the file operations/deployment/terraform/variables.tf.