### PR TITLE
AWS_MOUNT_EFS_ID vs AWS_EFS_MOUNT_ID

### DIFF
--- a/operations/_scripts/generate/generate_ansible_playbook.sh
+++ b/operations/_scripts/generate/generate_ansible_playbook.sh
@@ -48,7 +48,7 @@ echo -en "
   - name: Unmount efs
     include_tasks: tasks/umount.yml
 " >> $GITHUB_ACTION_PATH/operations/deployment/ansible/playbook.yml
-if [[ $(alpha_only "$AWS_EFS_CREATE") == true ]] || [[ $(alpha_only "$AWS_EFS_CREATE_HA") == true ]] || [[ $AWS_EFS_MOUNT_ID != "" ]]; then
+if [[ $(alpha_only "$AWS_EFS_CREATE") == true ]] || [[ $(alpha_only "$AWS_EFS_CREATE_HA") == true ]] || [[ $AWS_MOUNT_EFS_ID != "" ]]; then
 echo -en "
   - name: Mount efs
     include_tasks: tasks/mount.yml

--- a/operations/_scripts/generate/generate_tf_vars.sh
+++ b/operations/_scripts/generate/generate_tf_vars.sh
@@ -124,7 +124,7 @@ create_root_cert=$(generate_var create_root_cert $CREATE_ROOT_CERT)
 create_sub_cert=$(generate_var create_sub_cert $CREATE_SUB_CERT)
 no_cert=$(generate_var no_cert $NO_CERT)
 #-- EFS --#
-if [[ $(alpha_only "$AWS_EFS_CREATE") == true ]] || [[ $(alpha_only "$AWS_EFS_CREATE_HA") == true ]] || [[ $AWS_EFS_MOUNT_ID != "" ]]; then
+if [[ $(alpha_only "$AWS_EFS_CREATE") == true ]] || [[ $(alpha_only "$AWS_EFS_CREATE_HA") == true ]] || [[ $AWS_MOUNT_EFS_ID != "" ]]; then
   aws_create_efs=$(generate_var aws_create_efs $AWS_CREATE_EFS)
   aws_create_ha_efs=$(generate_var aws_create_ha_efs $AWS_CREATE_HA_EFS)
   aws_create_efs_replica=$(generate_var aws_create_efs_replica $AWS_CREATE_EFS_REPLICA)


### PR DESCRIPTION
When passing an EFS mount ID, variable was typed incorrectly, making it not to work. 